### PR TITLE
modify to return the prover's queryable height

### DIFF
--- a/pkg/proxy/prover.go
+++ b/pkg/proxy/prover.go
@@ -119,10 +119,15 @@ func (pr *Prover) SetupHeader(dst core.LightClientIBCQueryierI, baseSrcHeader co
 // UpdateLightWithHeader updates a header on the light client and returns the header and height corresponding to the chain
 func (pr *Prover) UpdateLightWithHeader() (header core.HeaderI, provableHeight int64, queryableHeight int64, err error) {
 	if pr.upstreamProxy != nil {
-		if _, _, _, err = pr.prover.UpdateLightWithHeader(); err != nil {
-			return
+		_, _, qh, err := pr.prover.UpdateLightWithHeader()
+		if err != nil {
+			return nil, 0, 0, err
 		}
-		return pr.upstreamProxy.UpdateLightWithHeader()
+		h, ph, _, err := pr.upstreamProxy.UpdateLightWithHeader()
+		if err != nil {
+			return nil, 0, 0, err
+		}
+		return h, ph, qh, nil
 	} else {
 		return pr.prover.UpdateLightWithHeader()
 	}


### PR DESCRIPTION
When upstream proxy is enabled, the height of the upstream is returned as the `queryableHeight` in `UpdateLightWithHeader()`, but it appears that it is correct that the height of the chain that the prover includes is returned.

According to the implementation, `queryableHeight` is used in the following.
  - QueryPacketCommitments
  - QueryPacketAcknowledgeCommitments
  - QueryUnreceivedPackets
  - QueryUnreceivedAcknowledgements
  - QueryPacket
  - QueryPacketAcknowledgement

On the other hand, `provableHeight` is used in the following, and since the height to be pointed to depends on whether upstream proxy verification is used or not, it seems better to keep the current implementation.
  - QueryPacketCommitmentWithProof
  - QueryAcknowledgementCommitmentWithProof
  - QueryClientConsensusStateWithProof
  - QueryClientStateWithProof
  - QueryConnectionWithProof
  - QueryChannelWithProof

Signed-off-by: Ryo Sato <ryo.sato@datachain.jp>